### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WhatsApp Proxy Discovery Server
 
-WhatsApp Proxy Discovery server | Allows WhatsApp Proxies to announce themselfs to the backend
+WhatsApp Proxy Discovery server | Allows WhatsApp Proxies to announce themselves to the backend
 
 ## Routes
 


### PR DESCRIPTION
The typo is also present in the 'About' section of this repo:

![image](https://user-images.githubusercontent.com/50231698/212125737-e2c8cb4e-4156-49a2-9df1-65c24eb29e4c.png)
